### PR TITLE
Changes Type from []string to string.

### DIFF
--- a/reset_types.go
+++ b/reset_types.go
@@ -3,7 +3,7 @@ package hetzner
 type Reset struct {
 	ServerIP        string   `json:"server_ip"`
 	ServerNumber    int      `json:"server_number"`
-	Type            []string `json:"type"`
+	Type            string 	 `json:"type"`
 	OperatingStatus string   `json:"operating_status"`
 }
 


### PR DESCRIPTION
When using this library to send server resets to hetzner I was receiving this error: 

> json: cannot unmarshal string into Go struct field Reset.type of type []string

Based on the docs here https://robot.your-server.de/doc/webservice/en.html#post-reset-server-ip I changed the type from []string to string.