### PR TITLE
Maps ResetCreateResponse into Reset

### DIFF
--- a/reset.go
+++ b/reset.go
@@ -49,16 +49,16 @@ func (s *ResetServiceImpl) Create(req *ResetCreateRequest) (*Reset, *http.Respon
 	path := fmt.Sprintf("/reset/%v", req.ServerIP)
 
 	type Data struct {
-		ResetResp *ResetCreateResponse `json:"reset"`
+		Reset *ResetCreateResponse `json:"reset"`
 	}
 
 	data := Data{}
 	resp, err := s.client.Call(http.MethodPost, path, req, &data, true)
 
 	out := &Reset {
-		data.ResetResp.ServerIP,
-		data.ResetResp.ServerNumber,
-		[]string{data.ResetResp.Type
+		data.Reset.ServerIP,
+		data.Reset.ServerNumber,
+		[]string{ data.Reset.Type },
 	}
 	return out, resp, err
 }

--- a/reset.go
+++ b/reset.go
@@ -9,7 +9,7 @@ import (
 type ResetService interface {
 	List() ([]*Reset, *http.Response, error)
 	Get(serverIP string) (*Reset, *http.Response, error)
-	Create(req *ResetCreateRequest) (*ResetCreateResponse, *http.Response, error)
+	Create(req *ResetCreateRequest) (*Reset, *http.Response, error)
 }
 
 type ResetServiceImpl struct {
@@ -45,13 +45,23 @@ func (s *ResetServiceImpl) Get(serverIP string) (*Reset, *http.Response, error) 
 	return data.Reset, resp, err
 }
 
-func (s *ResetServiceImpl) Create(req *ResetCreateRequest) (*ResetCreateResponse, *http.Response, error) {
+func (s *ResetServiceImpl) Create(req *ResetCreateRequest) (*Reset, *http.Response, error) {
 	path := fmt.Sprintf("/reset/%v", req.ServerIP)
 
 	type Data struct {
-		Reset *ResetCreateResponse `json:"reset"`
+		ResetResp *ResetCreateResponse `json:"reset"`
+		Reset     *Reset
 	}
+
 	data := Data{}
 	resp, err := s.client.Call(http.MethodPost, path, req, &data, true)
+
+	data.Reset = &Reset{
+		data.ResetResp.ServerIP,
+		data.ResetResp.ServerNumber,
+		[]string{data.ResetResp.Type},
+		"",
+	}
+
 	return data.Reset, resp, err
 }

--- a/reset.go
+++ b/reset.go
@@ -50,18 +50,15 @@ func (s *ResetServiceImpl) Create(req *ResetCreateRequest) (*Reset, *http.Respon
 
 	type Data struct {
 		ResetResp *ResetCreateResponse `json:"reset"`
-		Reset     *Reset
 	}
 
 	data := Data{}
 	resp, err := s.client.Call(http.MethodPost, path, req, &data, true)
 
-	data.Reset = &Reset{
+	out := &Reset {
 		data.ResetResp.ServerIP,
 		data.ResetResp.ServerNumber,
-		[]string{data.ResetResp.Type},
-		"",
+		[]string{data.ResetResp.Type
 	}
-
-	return data.Reset, resp, err
+	return out, resp, err
 }


### PR DESCRIPTION
Restores changes to interface and maps response into Reset to maintain BC.

This includes the upstream changes.